### PR TITLE
Bump Persimmon.Dried version to 1.2.0

### DIFF
--- a/Funcy.Test/packages.config
+++ b/Funcy.Test/packages.config
@@ -4,6 +4,6 @@
   <package id="FsRandom" version="1.3.3" targetFramework="net45" />
   <package id="Persimmon" version="1.0.0" targetFramework="net45" />
   <package id="Persimmon.Console" version="1.0.0" targetFramework="net45" />
-  <package id="Persimmon.Dried" version="1.1.0" targetFramework="net45" />
+  <package id="Persimmon.Dried" version="1.2.0" targetFramework="net45" />
   <package id="Persimmon.Runner" version="1.0.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
In order to use Arb.array.NonEmpty.