### PR TITLE
Bump Persimmon.Dried version to 1.2.0

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -5,5 +5,5 @@ nuget FsPickler 1.5.2 framework: >= net45
 nuget FsRandom 1.3.3 framework: >= net45
 nuget Persimmon 1.0.0 framework: >= net45
 nuget Persimmon.Console 1.0.0 framework: >= net45
-nuget Persimmon.Dried 1.1.0 framework: >= net45
+nuget Persimmon.Dried 1.2.0 framework: >= net45
 nuget Persimmon.Runner 1.0.0 framework: >= net45


### PR DESCRIPTION
In order to use Arb.array.NonEmpty